### PR TITLE
logging tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ Initialise the logger at the top level of the app, specifying the log locations 
 ```javascript
 var hmpoLogger = require('hmpo-logger');
 hmpoLogger.config({ // defaults:
-    logPublicRequests: false,
     console: true,
     connsoleJSON: false,
     consoleLevel: 'debug',
@@ -60,8 +59,8 @@ hmpoLogger.config({ // defaults:
     appJSON: true,
     appLevel: 'info',
     error: './error.log',
-    errorJSON: false,
-    errorLevel: ['error', 'warn'],
+    errorJSON: true,
+    errorLevel: 'exceptions',
     meta: {
         host: 'host',
         pm: 'env[pm_id]',
@@ -79,6 +78,8 @@ hmpoLogger.config({ // defaults:
         httpversion: 'version',
         bytes: 'res.content-length'
     },
+    logPublicRequests: false,
+    logHealthcheckRequests: false,
     format: ':clientip :sessionID :method :request HTTP/:httpVersion :statusCode :res[content-length] - :responseTime ms'
 });
 ```

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -1,8 +1,10 @@
 var winston = require('winston'),
-    morgan = require('morgan'),
     _ = require('underscore'),
     Logger = require('./logger'),
-    moduleName = require('./module-name');
+    moduleName = require('./module-name'),
+    onFinished = require('on-finished'),
+    onHeaders = require('on-headers');
+
 
 /* eslint "no-console":0 */
 
@@ -13,7 +15,6 @@ var Manager = function () {
 };
 
 Manager.defaultOptions = {
-    logPublicRequests: false,
     console: true,
     connsoleJSON: false,
     consoleLevel: 'debug',
@@ -22,8 +23,8 @@ Manager.defaultOptions = {
     appJSON: true,
     appLevel: 'info',
     error: './error.log',
-    errorJSON: false,
-    errorLevel: 'error',
+    errorJSON: true,
+    errorLevel: 'exceptions',
     meta: {
         host: 'host',
         pm: 'env[pm_id]',
@@ -41,6 +42,8 @@ Manager.defaultOptions = {
         httpversion: 'version',
         bytes: 'res.content-length'
     },
+    logPublicRequests: false,
+    logHealthcheckRequests: false,
     format: ':clientip :sessionID :method :request HTTP/:httpVersion :statusCode :res[content-length] - :responseTime ms'
 };
 
@@ -152,35 +155,62 @@ Manager.prototype.get = function (name) {
     return logger;
 };
 
+Manager.rePublicRequests = /\/public\//;
+Manager.reHealthcheckRequests = /^\/healthcheck(\/|$)/;
 
 Manager.prototype.middleware = function () {
     var options = this.getGlobal()._options;
 
     var logger = this.get(':express');
 
-    var middleware = function (req, res, next) {
-
-        morgan(' ', {
-            stream: {
-                write: function () {
-                    res.responseTime = res.responseTime || morgan['response-time'](req, res);
-
-                    if (options.logPublicRequests === false) {
-                        if (req.originalUrl.match(/\/public/)) {
-                            return;
-                        }
-                    }
-
-                    logger.request(options.format, {
-                        req: req,
-                        res: res
-                    });
-                }
-            }
-        })(req, res, next);
+    var timeDiff = function (from, to, digits) {
+        if (digits === undefined) { digits = 3; }
+        var ms = (to[0] - from[0]) * 1e3
+            + (to[1] - from[1]) * 1e-6;
+        return +ms.toFixed(digits);
     };
 
-    return middleware;
+    var handleHeaders = function (req, res) {
+        res._startAt = process.hrtime();
+        if (req._startAt && res._startAt) {
+            res.responseTime = timeDiff(req._startAt, res._startAt);
+        }
+    };
+
+    var handleFinished = function (req, res) {
+        res._endAt = process.hrtime();
+        if (res._startAt && res._endAt) {
+            res.transferTime = timeDiff(res._startAt, res._endAt);
+        }
+
+        var url = req.originalUrl || req.url || '';
+
+        if (options.logPublicRequests === false) {
+            if (url.match(Manager.rePublicRequests)) {
+                return;
+            }
+        }
+
+        if (options.logHealthcheckRequests === false) {
+            if (url.match(Manager.reHealthcheckRequests)) {
+                return;
+            }
+        }
+
+        logger.request(options.format, {
+            req: req,
+            res: res
+        });
+    };
+
+    return function (req, res, next) {
+        req._startAt = process.hrtime();
+
+        onHeaders(res, _.partial(handleHeaders, req, res));
+        onFinished(res, _.partial(handleFinished, req, res));
+
+        next();
+    };
 };
 
 module.exports = Manager;

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   },
   "homepage": "https://github.com/UKHomeOffice/passports-logger#readme",
   "dependencies": {
-    "morgan": "^1.7.0",
+    "on-finished": "^2.3.0",
+    "on-headers": "^1.0.1",
     "underscore": "^1.8.3",
     "winston": "^2.2.0"
   },

--- a/test/spec/spec.manager.js
+++ b/test/spec/spec.manager.js
@@ -54,7 +54,7 @@ describe('instance', function () {
             t[1].filename.should.equal('app.log');
 
             t[2].name.should.equal('error');
-            t[2].level.should.equal('error');
+            t[2].level.should.equal('exceptions');
             t[2].filename.should.equal('error.log');
         });
 


### PR DESCRIPTION
Replace morgan with on-headers and on-finished.
Add option to not log healthchecks.
Default to only logging exceptions to error log and in JSON format.
Add transferTime to res object, to compliment responseTime.
