### PR TITLE
Add unique id header to logs. augment default meta with configured meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ hmpoLogger.config({ // defaults:
     },
     requestMeta: {
         clientip: 'clientip',
+        uniqueID: 'x-uniq-id',
         remoteAddress: 'connection.remoteAddress',
         hostname: 'hostname',
         port: 'port',

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -34,6 +34,7 @@ Manager.defaultOptions = {
     },
     requestMeta: {
         clientip: 'clientip',
+        uniqueID: 'x-uniq-id',
         remoteAddress: 'connection.remoteAddress',
         hostname: 'hostname',
         port: 'port',
@@ -81,7 +82,28 @@ Manager.prototype.config = function (options) {
 
     global.GlobalHmpoLogger = this;
 
-    _.extend(this._options, options);
+    if (options) {
+        this._options = _.extend(
+            {},
+            Manager.defaultOptions,
+            options);
+
+        this._options.meta = _.pick(
+            _.extend(
+                {},
+                Manager.defaultOptions.meta,
+                options.meta
+            ),
+            _.isString);
+
+        this._options.requestMeta = _.pick(
+            _.extend(
+                {},
+                Manager.defaultOptions.requestMeta,
+                options.requestMeta
+            ),
+            _.isString);
+    }
 
     winston.addColors(Manager.levelColors);
 

--- a/test/spec/spec.manager.js
+++ b/test/spec/spec.manager.js
@@ -82,6 +82,23 @@ describe('instance', function () {
             t[2].filename.should.equal('testerror.log');
         });
 
+        it('should augment instead of overwriting configured meta data', function () {
+            manager.config({
+                meta: {
+                    host: undefined,
+                    request: null,
+                    extra: 'extravalue',
+                    verb: false
+                }
+            });
+
+            manager._options.meta.should.deep.equal({
+                pm: 'env[pm_id]',
+                sessionID: 'sessionID',
+                extra: 'extravalue'
+            });
+        });
+
     });
 
     describe('middleware', function () {


### PR DESCRIPTION
Add unique id header to logs.
Instead of overwriting meta data to be logged with config, extend defaults, or remove defaults by configuring the key to undefined.