### PR TITLE
Add logstash 1.2 formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ hmpoLogger.config({ // defaults:
         host: 'host',
         pm: 'env.pm_id',
         sessionID: 'sessionID',
-        verb: 'method',
+        method: 'method',
         request: 'request'
     },
     requestMeta: {

--- a/lib/logstash.js
+++ b/lib/logstash.js
@@ -1,0 +1,79 @@
+var _ = require('underscore'),
+    sortObject = require('sort-object-keys');
+
+var keys = [
+    '@timestamp',
+    'level',
+    '@message',
+    'message',
+    'clientip',
+    'sessionID',
+    'hostname',
+    'port',
+    'method',
+    'path',
+    'httpversion',
+    'response',
+    'responseTime',
+    'bytes',
+    'clientip',
+    'sessionID',
+    'uniqueID',
+    'host',
+    'pm',
+    'label',
+    '@fields',
+    'error',
+    'stack',
+    'type'
+];
+
+var serialize = function (data) {
+    var seen = [];
+    data = sortObject(data, keys);
+    return JSON.stringify(data, function (k, v) {
+        if (typeof v === 'function') {
+            return '[func]';
+        }
+        if (typeof v === 'object' && v) {
+            if (seen.indexOf(v) >=0) { return '[circular]'; }
+            seen.push(v);
+            return _.isArray(v) ? v : sortObject(v, keys);
+        }
+        return v;
+    });
+};
+
+module.exports = function (options) {
+    if (typeof options.meta !== 'object' && options.meta != null) {
+        options.meta = { meta: options.meta };
+    }
+    if (options.meta && typeof options.meta.message === 'string' && typeof options.meta.stack === 'string') {
+        var error = {};
+        error.message = options.meta.message;
+        delete options.meta.message;
+        error.stack = options.meta.stack.split(/\n\s+/).slice(1);
+        delete options.meta.stack;
+        if (options.meta.type) {
+            error.type = options.meta.type;
+            delete options.meta.type;
+        }
+        options.meta = _.extend({
+            error: error
+        }, options.meta);
+    }
+    var timestamp = typeof options.timestamp === 'function' ? options.timestamp() : new Date().toISOString();
+
+    var output = _.extend({}, options.meta, {
+        '@timestamp': timestamp,
+        'level': (options.level || 'DEBUG').toUpperCase(),
+        'message': options.message || ''
+    });
+
+    if (typeof options.stringify === 'function') {
+        return options.stringify(output);
+    }
+
+    return serialize(output);
+};
+

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -2,6 +2,7 @@ var winston = require('winston'),
     _ = require('underscore'),
     Logger = require('./logger'),
     moduleName = require('./module-name'),
+    logstash = require('./logstash'),
     onFinished = require('on-finished'),
     onHeaders = require('on-headers');
 
@@ -29,7 +30,7 @@ Manager.defaultOptions = {
         host: 'host',
         pm: 'env.pm_id',
         sessionID: 'sessionID',
-        verb: 'method',
+        method: 'method',
         request: 'request'
     },
     requestMeta: {
@@ -129,8 +130,9 @@ Manager.prototype.config = function (options) {
             new winston.transports.File({
                 name: 'app',
                 filename: this._options.app,
-                json: this._options.appJSON,
-                logstash: this._options.appJSON,
+                json: false,
+                logstash: false,
+                formatter: this._options.appJSON ? logstash : undefined,
                 level: this._options.appLevel
             })
         );
@@ -143,8 +145,9 @@ Manager.prototype.config = function (options) {
                 handleExceptions: true,
                 humanReadableUnhandledException: true,
                 filename: this._options.error,
-                json: this._options.errorJSON,
-                logstash: this._options.errorJSON,
+                json: false,
+                logstash: false,
+                formatter: this._options.appJSON ? logstash : undefined,
                 level: this._options.errorLevel
             })
         );

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "on-finished": "^2.3.0",
     "on-headers": "^1.0.1",
+    "sort-object-keys": "^1.1.2",
     "underscore": "^1.8.3",
     "winston": "^2.2.0"
   },

--- a/test/spec/spec.logger.js
+++ b/test/spec/spec.logger.js
@@ -246,9 +246,9 @@ describe('logger instance', function () {
                     label: 'test',
                     host: sinon.match.string,
                     sessionID: 'abc123',
+                    method: 'GET',
                     request: '/abc/123',
-                    responseTime: 5000,
-                    verb: 'GET'
+                    responseTime: 5000
                 }));
         });
 

--- a/test/spec/spec.logstash.js
+++ b/test/spec/spec.logstash.js
@@ -1,0 +1,144 @@
+
+var logstash = require('../../lib/logstash');
+
+
+describe('logstash', function () {
+    var options, clock, fakeTimestamp;
+
+    beforeEach(function () {
+        options = {
+            level: 'test',
+            message: 'test message',
+            stringify: function (v) { return v; }
+        };
+        clock = sinon.useFakeTimers(0);
+        fakeTimestamp = '1970-01-01T00:00:00.000Z';
+    });
+
+    afterEach(function () {
+        clock.restore();
+    });
+
+    it('should export a function that takes one argument', function () {
+        logstash.should.be.a('function');
+        logstash.should.have.length(1);
+    });
+
+    it('should set timestamp, level, and message', function () {
+        var output = logstash(options);
+        output.should.deep.equal({
+            '@timestamp': fakeTimestamp,
+            level: 'TEST',
+            message: 'test message'
+        });
+    });
+
+    it('should use empty message and default level if none set', function () {
+        delete options.level;
+        delete options.message;
+        var output = logstash(options);
+        output.should.deep.equal({
+            '@timestamp': fakeTimestamp,
+            level: 'DEBUG',
+            message: ''
+        });
+    });
+
+    it('should timestamp function if given', function () {
+        options.timestamp = function () { return 'test timestamp'; };
+        var output = logstash(options);
+        output.should.deep.equal({
+            '@timestamp': 'test timestamp',
+            level: 'TEST',
+            message: 'test message'
+        });
+    });
+
+    it('should set meta value if it is not an object', function () {
+        options.meta = 'meta string';
+        var output = logstash(options);
+        output.should.deep.equal({
+            '@timestamp': fakeTimestamp,
+            level: 'TEST',
+            message: 'test message',
+            meta: 'meta string'
+        });
+    });
+
+    it('should add meta values to output if it is an object', function () {
+        options.meta = {
+            key1: 'value1',
+            key2: 2
+        };
+        var output = logstash(options);
+        output.should.deep.equal({
+            '@timestamp': fakeTimestamp,
+            level: 'TEST',
+            message: 'test message',
+            key1: 'value1',
+            key2: 2
+        });
+    });
+
+    it('should add meta values to output if it is an error', function () {
+        options.meta = new Error('Error message');
+        options.meta.stack = 'Error\n  1\n  2\n  3';
+        options.meta.type = 'my_error';
+        var output = logstash(options);
+        output.should.deep.equal({
+            '@timestamp': fakeTimestamp,
+            level: 'TEST',
+            message: 'test message',
+            error: {
+                message: 'Error message',
+                stack: ['1', '2', '3'],
+                type: 'my_error'
+            }
+        });
+    });
+
+    it('should use the internal serialize function if no stringify is given', function () {
+        delete options.stringify;
+        options.meta = new Error('Error message');
+        options.meta.stack = 'Error\n  1\n  2\n  3';
+        var output = logstash(options);
+        output.should.equal(
+            '{' +
+            '"@timestamp":"1970-01-01T00:00:00.000Z",' +
+            '"level":"TEST",' +
+            '"message":"test message",' +
+            '"error":{"message":"Error message","stack":["1","2","3"]}' +
+            '}');
+    });
+
+    it('should handle functions and circular references when stringifying', function () {
+        delete options.stringify;
+        options.meta = {
+            string: 'string',
+            number: 12345,
+            float: 1.23456,
+            object: { foo: 'bar' },
+            array: [ 1, 2, 3 ],
+            func: function () {},
+            circular: {}
+        };
+        options.meta.circular.content = options.meta.circular;
+        var output = logstash(options);
+        output.should.equal(
+            '{' +
+            '"@timestamp":"1970-01-01T00:00:00.000Z",' +
+            '"level":"TEST",' +
+            '"message":"test message",' +
+            '"array":[1,2,3],' +
+            '"circular":{"content":"[circular]"},' +
+            '"float":1.23456,' +
+            '"func":"[func]",' +
+            '"number":12345,' +
+            '"object":{"foo":"bar"},' +
+            '"string":"string"' +
+            '}'
+        );
+    });
+
+});
+

--- a/test/spec/spec.manager.js
+++ b/test/spec/spec.manager.js
@@ -90,6 +90,19 @@ describe('instance', function () {
             t[2].filename.should.equal('testerror.log');
         });
 
+        it('should use non-logstash logging if JSON is false', function () {
+            manager.config({
+                appJSON: false,
+                errorJSON: false
+            });
+
+            var t = winston.loggers.options.transports;
+            t.length.should.equal(3);
+
+            expect(t[1].formatter).to.be.undefined;
+            expect(t[2].formatter).to.be.undefined;
+        });
+
         it('should disable transports that are specified as falsey', function () {
             manager.config({
                 console: false,
@@ -107,7 +120,7 @@ describe('instance', function () {
                     host: undefined,
                     request: null,
                     extra: 'extravalue',
-                    verb: false
+                    method: false
                 }
             });
 


### PR DESCRIPTION
Breaking change:
Use logstash 1.2+ formatter instead of winston's builtint logstash 1.1 formatter when appJSON or errorJSON is specified in config
also change "verb" to "method" for GET / POST etc 