### PR TITLE
Possible Bugfix: Inspect correct JSON flag

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -147,7 +147,7 @@ Manager.prototype.config = function (options) {
                 filename: this._options.error,
                 json: false,
                 logstash: false,
-                formatter: this._options.appJSON ? logstash : undefined,
+                formatter: this._options.errorJSON ? logstash : undefined,
                 level: this._options.errorLevel
             })
         );


### PR DESCRIPTION
Changes this._options.appJSON to this._options.errorJSON when setting the formatter for the 'error' transport.

Not sure whether this was a mistake or not. Apologies if it isn't.