### PR TITLE
Read modified-time of existing to allow log rotation on startup

### DIFF
--- a/lib/filerotatetransport.js
+++ b/lib/filerotatetransport.js
@@ -8,6 +8,7 @@ var winston = require('winston'),
 
 var FileRotate = function (options) {
     options = options || {};
+    debug('constructor options', options);
 
     if (options.maxsize && options.dateRotate) {
         throw new Error('Cannot set maxsize and dateRotate together');
@@ -17,7 +18,8 @@ var FileRotate = function (options) {
 
     this.dateRotate = options.dateRotate;
     if (this.dateRotate) {
-        this._dateRotateUpdateDay();
+        var logfileDate = this._getLogfileDate();
+        this._dateRotateUpdateDay(logfileDate);
     }
 };
 
@@ -25,8 +27,20 @@ util.inherits(FileRotate, winston.transports.File);
 
 FileRotate.prototype.name = 'filerotate';
 
-FileRotate.prototype._dateRotateUpdateDay = function () {
-    var d = new Date();
+FileRotate.prototype._getLogfileDate = function () {
+    var currentLogfile = path.join(this.dirname, this._basename);
+    var logfileDate;
+    try {
+        logfileDate = fs.statSync(currentLogfile).mtime;
+        debug('existing log file date', logfileDate);
+    } catch (e) {
+        debug('existing log file stat error', e);
+    }
+    return logfileDate;
+};
+
+FileRotate.prototype._dateRotateUpdateDay = function (date) {
+    var d = date || new Date();
     var year = d.getUTCFullYear();
     var month = d.getUTCMonth();
     var day = d.getUTCDate();


### PR DESCRIPTION
Read the last-modified-time of an existing log file so that the logs can be rotated on startup if the log file was last appended to on a previous day.