### PR TITLE
Handle unknown error levels correctly when merging app and error logs

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -121,7 +121,9 @@ Manager.prototype.config = function (options) {
     // and only using error logger at the most verbose level of the two
     if (this._options.app && this._options.app === this._options.error) {
         this._options.app = null;
-        if (Manager.levels[this._options.appLevel] > Manager.levels[this._options.errorLevel]) {
+        var appLevel = (Manager.levels[this._options.appLevel] + 1) || 0;
+        var errorLevel = (Manager.levels[this._options.errorLevel] + 1) || 0;
+        if (appLevel > errorLevel) {
             this._options.errorLevel = this._options.appLevel;
         }
         this._options.errorJSON = this._options.errorJSON || this._options.appJSON;

--- a/test/spec/spec.manager.js
+++ b/test/spec/spec.manager.js
@@ -133,6 +133,36 @@ describe('instance', function () {
             t[1].filename.should.equal('testapp.log');
         });
 
+        it('should use higher known level if error level is not known', function () {
+            manager.config({
+                app: './testapp.log',
+                appLevel: 'info',
+                error: './testapp.log',
+                errorLevel: 'unknownlevel'
+            });
+
+            var t = winston.loggers.options.transports;
+            t.length.should.equal(2);
+
+            t[1].name.should.equal('error');
+            t[1].level.should.equal('info');
+        });
+
+        it('should use higher known level if app level is not known', function () {
+            manager.config({
+                app: './testapp.log',
+                appLevel: 'unknownlevel',
+                error: './testapp.log',
+                errorLevel: 'info'
+            });
+
+            var t = winston.loggers.options.transports;
+            t.length.should.equal(2);
+
+            t[1].name.should.equal('error');
+            t[1].level.should.equal('info');
+        });
+
         it('should use non-logstash logging if JSON is false', function () {
             manager.config({
                 consoleJSON: false,


### PR DESCRIPTION
When the app and error log file names are the same, the manager merges them into a single log transport, otherwise log rotation gets confused.
Unknown error levels were resolving to an error level of `NaN` which was causing the unknown error level to be used for the merged app and error logfile. This was because `(1 > NaN) === false`
This fix treats unknown error levels as the lowest level, so the merged log file will use the correct highest level.